### PR TITLE
docs(emphasis): capitalise E on title

### DIFF
--- a/src/site/content/emphasis.md
+++ b/src/site/content/emphasis.md
@@ -1,5 +1,5 @@
 ---
-title: emphasis
+title: Emphasis
 ---
 
 Inside a paragraph, we can add text level semantics like *emphasis* and **strong emphasis**.


### PR DESCRIPTION
fixes #4

Expected behaviour: 

`E` should be capitalised as it is a title.

Current behaviour:

`e` is not capitalised.